### PR TITLE
Move some dev dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - redis
     env_file:
-      - .env
+      - .env.default
     mem_reservation: "128m"
     volumes:
       - '.:/app'

--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
   },
   "author": "articulate",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "ioredis": "^4.17.3",
+    "tinygen": "^0.2.0"
+  },
   "devDependencies": {
     "dotenv": "^8.2.0",
     "eslint": "^7.5.0",
     "eslint-plugin-jest": "^23.18.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
-    "ioredis": "^4.17.3",
-    "jest": "^26.1.0",
-    "tinygen": "^0.2.0"
+    "jest": "^26.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "author": "articulate",
   "license": "MIT",
   "dependencies": {
-    "ioredis": "^4.17.3",
     "tinygen": "^0.2.0"
   },
   "devDependencies": {
@@ -19,6 +18,7 @@
     "eslint": "^7.5.0",
     "eslint-plugin-jest": "^23.18.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
+    "ioredis": "^4.17.3",
     "jest": "^26.1.0"
   }
 }


### PR DESCRIPTION
To be used in the library, `tinygen` and `ioredis` need to be dependencies instead of dev dependencies. 

![](https://media.giphy.com/media/XxR9qcIwcf5Jq404Sx/giphy.gif)